### PR TITLE
Define `allocate` to `Class` instead.

### DIFF
--- a/src/class-new-fiber-safe.c
+++ b/src/class-new-fiber-safe.c
@@ -22,8 +22,8 @@ static mrb_value class_allocate(mrb_state *mrb, mrb_value cv)
 
 void mrb_mruby_class_new_fiber_safe_gem_init(mrb_state* mrb)
 {
-    struct RClass *mod = mrb->module_class;
-    mrb_define_method(mrb, mod, "allocate", class_allocate, MRB_ARGS_NONE());
+    struct RClass *cls = mrb->class_class;
+    mrb_define_method(mrb, cls, "allocate", class_allocate, MRB_ARGS_NONE());
 }
 
 void mrb_mruby_class_new_fiber_safe_gem_final(mrb_state* mrb)

--- a/test/class-new-fiber-safe.rb
+++ b/test/class-new-fiber-safe.rb
@@ -9,4 +9,6 @@ assert("Class#new") do
     C.new(123)
   end
   assert_equal f.resume, 123
+  assert_false Module.method_defined? :allocate
+  assert_true Class.method_defined? :allocate
 end


### PR DESCRIPTION
For compatibility with CRuby:
http://ruby-doc.org/core-2.4.2/Class.html#method-i-allocate